### PR TITLE
Changes for capturing webpage and rendering it to PDF.

### DIFF
--- a/lib/phantompy.cpp
+++ b/lib/phantompy.cpp
@@ -318,6 +318,20 @@ void ph_image_free(void *image) {
     img->deleteLater();
 }
 
+/****** PDF ******/
+
+void ph_frame_render_pdf(void *frame, const char *fileName) {
+    ph::Frame *f = (ph::Frame*)frame;
+    f->renderPdf(fileName);
+}
+
+void ph_frame_set_paper_size(void *frame, const char *paper_size) {
+    QJsonObject paperSizeObject = QJsonDocument::fromJson(QByteArray(paper_size)).object();
+    QVariantMap paperSizeMap = paperSizeObject.toVariantMap();
+    ph::Frame *f = (ph::Frame*)frame;
+    f->setPaperSize(paperSizeMap);
+}
+
 /****** Web Elements ******/
 
 void ph_webelement_free(void *element) {

--- a/lib/phantompy.hpp
+++ b/lib/phantompy.hpp
@@ -57,6 +57,10 @@ extern "C" {
     const char* ph_image_get_format(void* image);
     void ph_image_get_bytes(void *image, void *buffer, int64_t size);
 
+    //Frame PDF methods
+    void ph_frame_render_pdf(void *frame, const char *fileName);
+    void ph_frame_set_paper_size(void *frame, const char *paper_size);
+
     // Web Element and Web Element Collection methods
     void* ph_frame_find_first(void *frame, const char *selector); // TODO: deprectated
     void* ph_frame_find_all(void *frame, const char *selector);

--- a/lib/private/frame.cpp
+++ b/lib/private/frame.cpp
@@ -12,6 +12,14 @@ Frame::Frame(QWebFrame *frame, QObject *parent): QObject(parent) {
 
 Frame::~Frame() {}
 
+void Frame::setPaperSize(const QVariantMap &size) {
+    m_paperSize = size;
+}
+
+QVariantMap Frame::paperSize() const {
+    return m_paperSize;
+}
+
 
 QByteArray Frame::captureImage(const char *format, int quality) {
     p_frame->page()->setViewportSize(p_frame->contentsSize());
@@ -32,6 +40,142 @@ QByteArray Frame::captureImage(const char *format, int quality) {
 
     image.save(&buffer, format, quality);
     return buffer.buffer();
+}
+
+#define PDF_DPI 72            // Different defaults. OSX: 72, X11: 75(?), Windows: 96
+
+//This function is reused from https://github.com/ariya/phantomjs/blob/master/src/webpage.cpp#L1033
+qreal stringToPointSize(const QString &string) {
+    static const struct {
+        QString unit;
+        qreal factor;
+    } units[] = {
+        { "mm", 72 / 25.4 },
+        { "cm", 72 / 2.54 },
+        { "in", 72 },
+        { "px", 72.0 / PDF_DPI / 2.54 },
+        { "", 72.0 / PDF_DPI / 2.54 }
+    };
+    for (uint i = 0; i < sizeof(units) / sizeof(units[0]); ++i) {
+        if (string.endsWith(units[i].unit)) {
+            QString value = string;
+            value.chop(units[i].unit.length());
+            return value.toDouble() * units[i].factor;
+        }
+    }
+    return 0;
+}
+
+//This function is reused from https://github.com/ariya/phantomjs/blob/master/src/webpage.cpp#L1055
+qreal printMargin(const QVariantMap &map, const QString &key) {
+    const QVariant margin = map.value(key);
+    if (margin.isValid() && margin.canConvert(QVariant::String)) {
+        return stringToPointSize(margin.toString());
+    } else {
+        return 0;
+    }
+}
+
+//This function is reused mostly from https://github.com/ariya/phantomjs/blob/master/src/webpage.cpp#L1065
+bool Frame::renderPdf(const QString &fileName) {
+    QPrinter printer;
+    printer.setOutputFormat(QPrinter::PdfFormat);
+    printer.setOutputFileName(fileName);
+    printer.setResolution(PDF_DPI);
+    QVariantMap paperSize = m_paperSize;
+
+    if (paperSize.isEmpty()) {
+        const QSize pageSize = p_frame->contentsSize();
+        paperSize.insert("width", QString::number(pageSize.width()) + "px");
+        paperSize.insert("height", QString::number(pageSize.height()) + "px");
+        paperSize.insert("margin", "0px");
+    }
+
+    if (paperSize.contains("width") && paperSize.contains("height")) {
+        const QSizeF sizePt(ceil(stringToPointSize(paperSize.value("width").toString())),
+                            ceil(stringToPointSize(paperSize.value("height").toString())));
+        printer.setPaperSize(sizePt, QPrinter::Point);
+    } else if (paperSize.contains("format")) {
+        const QPrinter::Orientation orientation = paperSize.contains("orientation")
+                && paperSize.value("orientation").toString().compare("landscape", Qt::CaseInsensitive) == 0 ?
+                    QPrinter::Landscape : QPrinter::Portrait;
+        printer.setOrientation(orientation);
+        static const struct {
+            QString format;
+            QPrinter::PaperSize paperSize;
+        } formats[] = {
+            { "A0", QPrinter::A0 },
+            { "A1", QPrinter::A1 },
+            { "A2", QPrinter::A2 },
+            { "A3", QPrinter::A3 },
+            { "A4", QPrinter::A4 },
+            { "A5", QPrinter::A5 },
+            { "A6", QPrinter::A6 },
+            { "A7", QPrinter::A7 },
+            { "A8", QPrinter::A8 },
+            { "A9", QPrinter::A9 },
+            { "B0", QPrinter::B0 },
+            { "B1", QPrinter::B1 },
+            { "B2", QPrinter::B2 },
+            { "B3", QPrinter::B3 },
+            { "B4", QPrinter::B4 },
+            { "B5", QPrinter::B5 },
+            { "B6", QPrinter::B6 },
+            { "B7", QPrinter::B7 },
+            { "B8", QPrinter::B8 },
+            { "B9", QPrinter::B9 },
+            { "B10", QPrinter::B10 },
+            { "C5E", QPrinter::C5E },
+            { "Comm10E", QPrinter::Comm10E },
+            { "DLE", QPrinter::DLE },
+            { "Executive", QPrinter::Executive },
+            { "Folio", QPrinter::Folio },
+            { "Ledger", QPrinter::Ledger },
+            { "Legal", QPrinter::Legal },
+            { "Letter", QPrinter::Letter },
+            { "Tabloid", QPrinter::Tabloid }
+        };
+        printer.setPaperSize(QPrinter::Letter); // Fallback
+        for (uint i = 0; i < sizeof(formats) / sizeof(formats[0]); ++i) {
+            if (paperSize.value("format").toString().compare(formats[i].format, Qt::CaseInsensitive) == 0) {
+                printer.setPaperSize(formats[i].paperSize);
+                break;
+            }
+        }
+    } else {
+        return false;
+    }
+    if (paperSize.contains("border") && !paperSize.contains("margin")) {
+        // backwards compatibility
+        paperSize["margin"] = paperSize["border"];
+    }
+
+    qreal marginLeft = 0;
+    qreal marginTop = 0;
+    qreal marginRight = 0;
+    qreal marginBottom = 0;
+
+    if (paperSize.contains("margin")) {
+        const QVariant margins = paperSize["margin"];
+        if (margins.canConvert(QVariant::Map)) {
+            const QVariantMap map = margins.toMap();
+            marginLeft = printMargin(map, "left");
+            marginTop = printMargin(map, "top");
+            marginRight = printMargin(map, "right");
+            marginBottom = printMargin(map, "bottom");
+        } else if (margins.canConvert(QVariant::String)) {
+            const qreal margin = stringToPointSize(margins.toString());
+            marginLeft = margin;
+            marginTop = margin;
+            marginRight = margin;
+            marginBottom = margin;
+        }
+    }
+
+    printer.setPageMargins(marginLeft, marginTop, marginRight, marginBottom, QPrinter::Point);
+
+    p_frame->print(&printer);
+    return true;
 }
 
 QString Frame::toHtml() {

--- a/lib/private/frame.hpp
+++ b/lib/private/frame.hpp
@@ -14,7 +14,12 @@ public:
     Frame(QWebFrame *frame, QObject *parent=0);
     ~Frame();
 
+    //PDF output options
+    void setPaperSize(const QVariantMap &size);
+    QVariantMap paperSize() const;
+
     QByteArray captureImage(const char *format, int quality);
+    bool renderPdf(const QString &filename);
     QString toHtml();
     QVariant evaluateJavaScript(const QString &data, bool expectLoad, int timeout);
 
@@ -27,6 +32,7 @@ public:
 
 private:
     QWebFrame *p_frame;
+    QVariantMap m_paperSize; // For PDF output
     QEventLoop m_loop;
 
 private slots:

--- a/phantompy/api.py
+++ b/phantompy/api.py
@@ -131,6 +131,13 @@ try:
     _library.ph_image_get_bytes.argtypes = [c_void_p, c_void_p, c_longlong]
     _library.ph_image_get_bytes.restype = None
 
+    # PDF methods
+    _library.ph_frame_render_pdf.argtypes = [c_void_p, c_char_p]
+    _library.ph_frame_render_pdf.restype = None
+
+    _library.ph_frame_set_paper_size.argtypes = [c_void_p, c_char_p]
+    _library.ph_frame_set_paper_size.restype = None
+
     # Web Element Collection methods
     _library.ph_webcollection_size.argtypes = [c_void_p]
     _library.ph_webcollection_size.restype = c_int

--- a/phantompy/page.py
+++ b/phantompy/page.py
@@ -45,6 +45,53 @@ class Frame(object):
         image_ptr = lib.ph_frame_capture_image(self.ptr, _format, quality)
         return image.Image(image_ptr, format, quality, self)
 
+    #Set paper size for PDF output
+    def set_paper_size(self, paper_size_dict):
+        arguments = {
+            'width':            { },
+            'height' :          { },
+            'margin':           { },
+            'format':           {'values': ['A0', 'A1', 'A2', 'A3', 'A4', 'A5', 'A6', 'A7', 'A8',
+                                             'A9', 'B0', 'B1', 'B2', 'B3', 'B4', 'B5', 'B6', 'B7',
+                                             'B8', 'B9', 'B10', 'C5E', 'Comm10E', 'DLE', 'Executive',
+                                             'Folio', 'Ledger', 'Legal', 'Letter', 'Tabloid']  },
+            'orientation':      { 'values':['landscape', 'potrait'] },
+        }
+
+        result = {}
+        paper_format = paper_size_dict.get('format')
+        paper_orientation = paper_size_dict.get('orientation')
+
+        if 'height' in paper_size_dict and 'width' in paper_size_dict and 'margin' in paper_size_dict:
+            result['height'] = paper_size_dict['height']
+            result['width'] = paper_size_dict['width']
+            result['margin'] = paper_size_dict['margin']
+
+        if paper_format:
+            if paper_format.lower() in (value.lower() for value in arguments['format']['values']):
+                result['format'] = paper_size_dict['format']
+            else:
+                raise ValueError('Valid values for the argument "%s" are %s' % ('format', arguments['format']['values']))
+
+
+        if paper_orientation:
+            if paper_orientation.lower() in (value.lower() for value in arguments['orientation']['values']):
+                result['orientation'] = paper_size_dict['orientation']
+            else:
+                raise ValueError('Valid values for the argument "%s" are %s' % ('orientation', arguments['orientation']['values']))
+
+        if not result:
+            raise ValueError('Either format or orientation or (height, width and height) are expected')
+
+        lib.ph_frame_set_paper_size(self.ptr, util.force_bytes(json.dumps(paper_size_dict)))
+
+        return None
+
+    #Output to PDF
+    def to_pdf(self, fileName):
+        lib.ph_frame_render_pdf(self.ptr, fileName)
+        return None
+
     def evaluate(self, js, expect_load=False, timeout=6000):
         js = util.force_bytes(js)
         result = lib.ph_frame_evaluate_javascript(self.ptr, js, expect_load, timeout)


### PR DESCRIPTION
Added functionality to render webpages to PDF. An example to generate PDF with the latest changes is as follows:-

> > > import phantompy as ph
> > > ctx = ph.context.context()
> > > frame = ph.open("https://facebook.com")
> > > frame.set_paper_size({'orientation':'landscape', 'format':'Letter'})
> > > frame.to_pdf('/home/ashish/test.pdf')
